### PR TITLE
Refactored spanText

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.bornfight.androidframework"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.31'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.gms:google-services:4.0.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.google.gms:google-services:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jul 02 10:33:40 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 // JitPack
 group="degordian.com"
-version="0.91"
+version="0.95"
 
 
 android {
@@ -13,7 +13,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -38,7 +38,7 @@ dependencies {
     // Various dependencies ========================================
 
     implementation 'org.ocpsoft.prettytime:prettytime:4.0.1.Final'
-    implementation 'com.github.bumptech.glide:glide:4.8.0'
+    implementation 'com.github.bumptech.glide:glide:4.9.0'
 
     // ==============================================================
 
@@ -52,20 +52,20 @@ dependencies {
 
     // RxJava2
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.5'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.6'
     implementation 'com.artemzin.rxjava:proguard-rules:1.1.5.0'
 
     //Retrofit & Networking
-    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
 
     // Play Services
     //implementation 'com.google.android.gms:play-services-location:16.0.0'
-    implementation 'com.google.android.gms:play-services-maps:16.0.0'
+    implementation 'com.google.android.gms:play-services-maps:17.0.0'
 
 
     // Firebase
-    implementation 'com.google.firebase:firebase-core:16.0.8'
+    implementation 'com.google.firebase:firebase-core:17.0.0'
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/utils/src/main/java/com/bornfight/utils/HtmlUtils.kt
+++ b/utils/src/main/java/com/bornfight/utils/HtmlUtils.kt
@@ -38,7 +38,7 @@ fun String?.spanHtml(): Spanned {
  * @param formName [MultipartBody.Part.createFormData] name ]
  * @return [MultipartBody.Part.createFormData] result
  */
-fun MultipartBody.Part.createFormData(contentUri: Uri, mediaType: String, formName: String): MultipartBody.Part {
+fun createFormData(contentUri: Uri, mediaType: String, formName: String): MultipartBody.Part {
     val imageFile = File(contentUri.path)
     val fileReqBody = RequestBody.create(MediaType.parse(mediaType), imageFile)
     return MultipartBody.Part.createFormData(formName, imageFile.name, fileReqBody)

--- a/utils/src/main/java/com/bornfight/utils/TextViewUtil.kt
+++ b/utils/src/main/java/com/bornfight/utils/TextViewUtil.kt
@@ -3,11 +3,13 @@ package com.bornfight.utils
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
+import android.text.method.LinkMovementMethod
 import android.text.style.CharacterStyle
 import android.text.style.ClickableSpan
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.view.View
+import android.widget.TextView
 
 /**
  * Created by tomislav on 20/03/2018.
@@ -94,4 +96,13 @@ object TextViewUtil {
 
         return spannedText
     }
+}
+
+
+/**
+ * Span HTML content with links, make them clickable and open them in CustomTab
+ */
+fun TextView.spanHtml(htmlContent: String?, spanPlainTextLinks: Boolean = true) {
+    this.text = TextViewUtil.spanText(htmlContent, spanPlainTextLinks) { this.context.launchUrl(it) }
+    this.movementMethod = LinkMovementMethod.getInstance()
 }


### PR DESCRIPTION
I thought that sending TextView as a parameter here is not the cleanest idea, in addition to sometimes wanting that spanned string as a variable.

With:
`val pero = TextView(this)
`
now you can write:
`pero.text = TextViewUtil.spanText(content, false) { launchUrl(it) }
`
(and also `val pero2 = TextViewUtil.spanText(content, false) { launchUrl(it, R.color.black) }`)

instead of old:
`TextViewUtil.spanText(pero, content, false)
`
or even

```
TextViewUtil.spanText(pero, "", false, object : TextViewUtil.OnUrlClickListener{
    override fun onUrlClicked(url: String) {
        launchUrl(url, R.color.black)
    }
})

```
Another benefit from this is that the context is not neccessary, (because it was required only to set the text which we don’t want, and launching customtabs, which is short enough on its own, especially because it’s an extension fun) so this can get called from anywhere just for the purpose of spanning text (what it’s name says it does :) ) 

Another thing, is this neccessary?
`var hrefSpannable = setCustomUrlSpans(SpannableString(htmlContent.spanHtml()), onUrlClick)
`
I remember that it maybe was, but perhaps we could lose setCustomUrlSpans()

`var hrefSpannable = SpannableString(htmlContent.spanHtml())
`