### PR TITLE
fix: added view type to generic adapter method

### DIFF
--- a/utils/src/main/java/com/bornfight/utils/adapters/GenericAdapter2.kt
+++ b/utils/src/main/java/com/bornfight/utils/adapters/GenericAdapter2.kt
@@ -55,7 +55,7 @@ abstract class GenericAdapter2<T, R> : RecyclerView.Adapter<GenericViewHolder<T>
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GenericViewHolder<T> {
-        val binding = createBinding(parent)
+        val binding = createBinding(parent, viewType)
         return getViewHolder(binding)
     }
 
@@ -69,7 +69,7 @@ abstract class GenericAdapter2<T, R> : RecyclerView.Adapter<GenericViewHolder<T>
 
     protected abstract fun getViewHolder(binding: R): GenericViewHolder<T>
 
-    protected abstract fun createBinding(parent: ViewGroup): R
+    protected abstract fun createBinding(parent: ViewGroup, viewType: Int): R
 
     abstract class GenericViewHolder<T>(itemView: View) : RecyclerView.ViewHolder(itemView) {
         abstract fun bind(data: T)


### PR DESCRIPTION
We have a case where we need current viewType to create appropriate ViewBinding class.